### PR TITLE
Fix: NullReferenceException when used in conjunction with Fluffy's Animal Tab.

### DIFF
--- a/Better Sliders/Better Sliders.csproj
+++ b/Better Sliders/Better Sliders.csproj
@@ -17,5 +17,9 @@
     <ItemGroup>
         <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4063" />
         <PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
+        <PackageReference Include="Krafs.Publicizer" Version="2.3.0" />
+    </ItemGroup>
+    <ItemGroup>
+        <Publicize Include="Assembly-CSharp:Verse.WindowStack.focusedWindow" />
     </ItemGroup>
 </Project>

--- a/Better Sliders/HarmonyPatches/ExpandedSliderFloat.cs
+++ b/Better Sliders/HarmonyPatches/ExpandedSliderFloat.cs
@@ -42,18 +42,11 @@ public static class ExpandedSliderFloat
     }
 
     [SuppressMessage("ReSharper", "RedundantAssignment")]
-    private static bool Prefix(ref Rect rect, FloatRange range, [NotNull] ref (NumberEntryController, bool) __state)
+    private static bool Prefix(ref Rect rect, FloatRange range, [NotNull] ref NumberEntryController __state)
     {
-        var tempState = SliderController.ControllerForPosition(rect);
+        __state = SliderController.ControllerForPosition(rect);
 
-        if (tempState == null)
-        {
-            __state = (null, false);
-            return false;
-        }
-
-        __state = (tempState, true);
-        __state.Item1.SetStateIfNull(range.min, range.max);
+        __state.SetStateIfNull(range.min, range.max);
 
         GameFont cache = Text.Font;
         Text.Font = GameFont.Tiny;
@@ -62,17 +55,17 @@ public static class ExpandedSliderFloat
 
         float usedWidth = rect.width - gapRect.width - 10f;
         float distributedWidth = usedWidth / 4f;
-        __state.Item1.MinimumEntryRect = new Rect(rect.x, rect.y, distributedWidth, Text.LineHeight);
-        __state.Item1.MaximumEntryRect = new Rect(gapRect.x + gapRect.width + __state.Item1.MinimumEntryRect.Value.width + 5f, rect.y, distributedWidth, Text.LineHeight);
+        __state.MinimumEntryRect = new Rect(rect.x, rect.y, distributedWidth, Text.LineHeight);
+        __state.MaximumEntryRect = new Rect(gapRect.x + gapRect.width + __state.MinimumEntryRect.Value.width + 5f, rect.y, distributedWidth, Text.LineHeight);
 
         Text.Font = cache;
 
         if (SliderSettings.IsAlwaysOn)
         {
             rect = new Rect(
-                __state.Item1.MinimumEntryRect.Value.x + __state.Item1.MinimumEntryRect.Value.width + 5f,
+                __state.MinimumEntryRect.Value.x + __state.MinimumEntryRect.Value.width + 5f,
                 rect.y,
-                rect.width - __state.Item1.MaximumEntryRect.Value.width - __state.Item1.MaximumEntryRect.Value.width - 10f,
+                rect.width - __state.MaximumEntryRect.Value.width - __state.MaximumEntryRect.Value.width - 10f,
                 rect.height
             );
         }
@@ -80,29 +73,26 @@ public static class ExpandedSliderFloat
         return true;
     }
 
-    private static void Postfix(Rect rect, ref FloatRange range, float min, float max, ToStringStyle valueStyle, [NotNull] ref (NumberEntryController, bool) __state)
+    private static void Postfix(Rect rect, ref FloatRange range, float min, float max, ToStringStyle valueStyle, [NotNull] ref NumberEntryController __state)
     {
-        if (!__state.Item2)
-            return;
-
         GameFont cache = Text.Font;
         Text.Font = GameFont.Tiny;
 
-        __state.Item1.BeginHysteresis(rect);
+        __state.BeginHysteresis(rect);
 
-        bool active = __state.Item1.IsCurrentlyActive();
+        bool active = __state.IsCurrentlyActive();
 
         if (active)
         {
-            __state.Item1.BeginLogging();
-            __state.Item1.Draw(ref range.min, ref range.max);
+            __state.BeginLogging();
+            __state.Draw(ref range.min, ref range.max);
         }
 
-        __state.Item1.EndHysteresis();
+        __state.EndHysteresis();
 
         if (!active)
         {
-            __state.Item1.EndLogging();
+            __state.EndLogging();
         }
 
         range.min = Mathf.Clamp(range.min, min, range.max);

--- a/Better Sliders/HarmonyPatches/ExpandedSliderFloat.cs
+++ b/Better Sliders/HarmonyPatches/ExpandedSliderFloat.cs
@@ -42,10 +42,18 @@ public static class ExpandedSliderFloat
     }
 
     [SuppressMessage("ReSharper", "RedundantAssignment")]
-    private static void Prefix(ref Rect rect, FloatRange range, [NotNull] ref NumberEntryController __state)
+    private static bool Prefix(ref Rect rect, FloatRange range, [NotNull] ref (NumberEntryController, bool) __state)
     {
-        __state = SliderController.ControllerForPosition(rect);
-        __state.SetStateIfNull(range.min, range.max);
+        var tempState = SliderController.ControllerForPosition(rect);
+
+        if (tempState == null)
+        {
+            __state = (null, false);
+            return false;
+        }
+
+        __state = (tempState, true);
+        __state.Item1.SetStateIfNull(range.min, range.max);
 
         GameFont cache = Text.Font;
         Text.Font = GameFont.Tiny;
@@ -54,42 +62,47 @@ public static class ExpandedSliderFloat
 
         float usedWidth = rect.width - gapRect.width - 10f;
         float distributedWidth = usedWidth / 4f;
-        __state.MinimumEntryRect = new Rect(rect.x, rect.y, distributedWidth, Text.LineHeight);
-        __state.MaximumEntryRect = new Rect(gapRect.x + gapRect.width + __state.MinimumEntryRect.Value.width + 5f, rect.y, distributedWidth, Text.LineHeight);
+        __state.Item1.MinimumEntryRect = new Rect(rect.x, rect.y, distributedWidth, Text.LineHeight);
+        __state.Item1.MaximumEntryRect = new Rect(gapRect.x + gapRect.width + __state.Item1.MinimumEntryRect.Value.width + 5f, rect.y, distributedWidth, Text.LineHeight);
 
         Text.Font = cache;
 
         if (SliderSettings.IsAlwaysOn)
         {
             rect = new Rect(
-                __state.MinimumEntryRect.Value.x + __state.MinimumEntryRect.Value.width + 5f,
+                __state.Item1.MinimumEntryRect.Value.x + __state.Item1.MinimumEntryRect.Value.width + 5f,
                 rect.y,
-                rect.width - __state.MaximumEntryRect.Value.width - __state.MaximumEntryRect.Value.width - 10f,
+                rect.width - __state.Item1.MaximumEntryRect.Value.width - __state.Item1.MaximumEntryRect.Value.width - 10f,
                 rect.height
             );
         }
+
+        return true;
     }
 
-    private static void Postfix(Rect rect, ref FloatRange range, float min, float max, ToStringStyle valueStyle, [NotNull] ref NumberEntryController __state)
+    private static void Postfix(Rect rect, ref FloatRange range, float min, float max, ToStringStyle valueStyle, [NotNull] ref (NumberEntryController, bool) __state)
     {
+        if (!__state.Item2)
+            return;
+
         GameFont cache = Text.Font;
         Text.Font = GameFont.Tiny;
 
-        __state.BeginHysteresis(rect);
+        __state.Item1.BeginHysteresis(rect);
 
-        bool active = __state.IsCurrentlyActive();
+        bool active = __state.Item1.IsCurrentlyActive();
 
         if (active)
         {
-            __state.BeginLogging();
-            __state.Draw(ref range.min, ref range.max);
+            __state.Item1.BeginLogging();
+            __state.Item1.Draw(ref range.min, ref range.max);
         }
 
-        __state.EndHysteresis();
+        __state.Item1.EndHysteresis();
 
         if (!active)
         {
-            __state.EndLogging();
+            __state.Item1.EndLogging();
         }
 
         range.min = Mathf.Clamp(range.min, min, range.max);

--- a/Better Sliders/HarmonyPatches/ExpandedSliderHorizontal.cs
+++ b/Better Sliders/HarmonyPatches/ExpandedSliderHorizontal.cs
@@ -47,57 +47,46 @@ public static class ExpandedSliderHorizontal
     }
 
     [SuppressMessage("ReSharper", "RedundantAssignment")]
-    private static bool Prefix(ref Rect rect, float value, [NotNull] ref (NumberEntryController, bool) __state)
+    private static bool Prefix(ref Rect rect, float value, [NotNull] ref NumberEntryController __state)
     {
-        var tempState = SliderController.ControllerForPosition(rect);
-
-        if (tempState == null)
-        {
-            __state = (null, false);
-            return false;
-        }
-
-        __state = (tempState, true);
-        __state.Item1.SetStateIfNull(value);
+        __state = SliderController.ControllerForPosition(rect);
+        __state.SetStateIfNull(value);
 
         GameFont cache = Text.Font;
         Text.Font = GameFont.Tiny;
 
         float fieldWidth = rect.width / 5f;
-        __state.Item1.MinimumEntryRect = new Rect(rect.x + rect.width - fieldWidth, rect.y, fieldWidth, Text.LineHeight);
+        __state.MinimumEntryRect = new Rect(rect.x + rect.width - fieldWidth, rect.y, fieldWidth, Text.LineHeight);
         Text.Font = cache;
 
         if (SliderSettings.IsAlwaysOn)
         {
-            rect = new Rect(rect.x, rect.y, rect.width - __state.Item1.MinimumEntryRect.Value.width - 5f, rect.height);
+            rect = new Rect(rect.x, rect.y, rect.width - __state.MinimumEntryRect.Value.width - 5f, rect.height);
         }
 
         return true;
     }
 
-    private static void Postfix(Rect rect, ref float __result, float roundTo, [NotNull] ref (NumberEntryController, bool) __state)
+    private static void Postfix(Rect rect, ref float __result, float roundTo, [NotNull] ref NumberEntryController __state)
     {
-        if (!__state.Item2)
-            return;
-
         GameFont cache = Text.Font;
         Text.Font = GameFont.Tiny;
 
-        __state.Item1.BeginHysteresis(rect);
+        __state.BeginHysteresis(rect);
 
-        bool active = __state.Item1.IsCurrentlyActive();
+        bool active = __state.IsCurrentlyActive();
 
         if (active)
         {
-            __state.Item1.BeginLogging();
-            __state.Item1.Draw(ref __result);
+            __state.BeginLogging();
+            __state.Draw(ref __result);
         }
 
-        __state.Item1.EndHysteresis();
+        __state.EndHysteresis();
 
         if (!active)
         {
-            __state.Item1.EndLogging();
+            __state.EndLogging();
         }
 
         Text.Font = cache;

--- a/Better Sliders/HarmonyPatches/ExpandedSliderInt.cs
+++ b/Better Sliders/HarmonyPatches/ExpandedSliderInt.cs
@@ -42,15 +42,15 @@ public static class ExpandedSliderInt
     }
 
     [SuppressMessage("ReSharper", "RedundantAssignment")]
-    private static void Prefix(ref Rect rect, IntRange range, [NotNull] ref NumberEntryController __state, out bool __continue)
+    private static bool Prefix(ref Rect rect, IntRange range, [NotNull] ref NumberEntryController __state, out bool ___continue)
     {
-        __continue = true;
+        ___continue = true;
         var tempState = SliderController.ControllerForPosition(rect);
 
         if (tempState == null)
         {
-            __continue = false;
-            return;
+            ___continue = false;
+            return false;
         }
 
         __state = tempState;
@@ -72,11 +72,13 @@ public static class ExpandedSliderInt
         {
             rect = new Rect(__state.MinimumEntryRect.Value.x + __state.MinimumEntryRect.Value.width + 5f, rect.y, usedWidth - 10f, rect.height);
         }
+
+        return true;
     }
 
-    private static void Postfix(Rect rect, ref IntRange range, int min, int max, [NotNull] ref NumberEntryController __state, bool __continue)
+    private static void Postfix(Rect rect, ref IntRange range, int min, int max, [NotNull] ref NumberEntryController __state, bool ___continue)
     {
-        if (!__continue)
+        if (!___continue)
         {
             return;
         }

--- a/Better Sliders/HarmonyPatches/ExpandedSliderInt.cs
+++ b/Better Sliders/HarmonyPatches/ExpandedSliderInt.cs
@@ -42,18 +42,10 @@ public static class ExpandedSliderInt
     }
 
     [SuppressMessage("ReSharper", "RedundantAssignment")]
-    private static bool Prefix(ref Rect rect, IntRange range, [NotNull] ref (NumberEntryController, bool) __state)
+    private static bool Prefix(ref Rect rect, IntRange range, [NotNull] ref NumberEntryController __state)
     {
-        var tempState = SliderController.ControllerForPosition(rect);
-
-        if (tempState == null)
-        {
-            __state = (null, false);
-            return false;
-        }
-
-        __state = (tempState, true);
-        __state.Item1.SetStateIfNull(range.min, range.max);
+        __state = SliderController.ControllerForPosition(rect);
+        __state.SetStateIfNull(range.min, range.max);
 
         GameFont cache = Text.Font;
         Text.Font = GameFont.Tiny;
@@ -62,42 +54,39 @@ public static class ExpandedSliderInt
 
         float usedWidth = rect.width - gapRect.width - 10f;
         float distributedWidth = usedWidth / 4f;
-        __state.Item1.MinimumEntryRect = new Rect(rect.x, rect.y, distributedWidth, Text.LineHeight);
-        __state.Item1.MaximumEntryRect = new Rect(gapRect.x + gapRect.width + __state.Item1.MinimumEntryRect.Value.width + 5f, rect.y, distributedWidth, Text.LineHeight);
+        __state.MinimumEntryRect = new Rect(rect.x, rect.y, distributedWidth, Text.LineHeight);
+        __state.MaximumEntryRect = new Rect(gapRect.x + gapRect.width + __state.MinimumEntryRect.Value.width + 5f, rect.y, distributedWidth, Text.LineHeight);
 
         Text.Font = cache;
 
         if (SliderSettings.IsAlwaysOn)
         {
-            rect = new Rect(__state.Item1.MinimumEntryRect.Value.x + __state.Item1.MinimumEntryRect.Value.width + 5f, rect.y, usedWidth - 10f, rect.height);
+            rect = new Rect(__state.MinimumEntryRect.Value.x + __state.MinimumEntryRect.Value.width + 5f, rect.y, usedWidth - 10f, rect.height);
         }
 
         return true;
     }
 
-    private static void Postfix(Rect rect, ref IntRange range, int min, int max, [NotNull] ref (NumberEntryController, bool) __state)
+    private static void Postfix(Rect rect, ref IntRange range, int min, int max, [NotNull] ref NumberEntryController __state)
     {
-        if (!__state.Item2)
-            return;
-
         GameFont cache = Text.Font;
         Text.Font = GameFont.Tiny;
 
-        __state.Item1.BeginHysteresis(rect);
+        __state.BeginHysteresis(rect);
 
-        bool active = __state.Item1.IsCurrentlyActive();
+        bool active = __state.IsCurrentlyActive();
 
         if (active)
         {
-            __state.Item1.BeginLogging();
-            __state.Item1.Draw(ref range.min, ref range.max);
+            __state.BeginLogging();
+            __state.Draw(ref range.min, ref range.max);
         }
 
-        __state.Item1.EndHysteresis();
+        __state.EndHysteresis();
 
         if (!active)
         {
-            __state.Item1.EndLogging();
+            __state.EndLogging();
         }
 
         range.min = Mathf.Clamp(range.min, min, range.max);

--- a/Better Sliders/HarmonyPatches/ExpandedSliderInt.cs
+++ b/Better Sliders/HarmonyPatches/ExpandedSliderInt.cs
@@ -42,19 +42,18 @@ public static class ExpandedSliderInt
     }
 
     [SuppressMessage("ReSharper", "RedundantAssignment")]
-    private static bool Prefix(ref Rect rect, IntRange range, [NotNull] ref NumberEntryController __state, out bool ___continue)
+    private static bool Prefix(ref Rect rect, IntRange range, [NotNull] ref (NumberEntryController, bool) __state)
     {
-        ___continue = true;
         var tempState = SliderController.ControllerForPosition(rect);
 
         if (tempState == null)
         {
-            ___continue = false;
+            __state = (null, false);
             return false;
         }
 
-        __state = tempState;
-        __state.SetStateIfNull(range.min, range.max);
+        __state = (tempState, true);
+        __state.Item1.SetStateIfNull(range.min, range.max);
 
         GameFont cache = Text.Font;
         Text.Font = GameFont.Tiny;
@@ -63,44 +62,42 @@ public static class ExpandedSliderInt
 
         float usedWidth = rect.width - gapRect.width - 10f;
         float distributedWidth = usedWidth / 4f;
-        __state.MinimumEntryRect = new Rect(rect.x, rect.y, distributedWidth, Text.LineHeight);
-        __state.MaximumEntryRect = new Rect(gapRect.x + gapRect.width + __state.MinimumEntryRect.Value.width + 5f, rect.y, distributedWidth, Text.LineHeight);
+        __state.Item1.MinimumEntryRect = new Rect(rect.x, rect.y, distributedWidth, Text.LineHeight);
+        __state.Item1.MaximumEntryRect = new Rect(gapRect.x + gapRect.width + __state.Item1.MinimumEntryRect.Value.width + 5f, rect.y, distributedWidth, Text.LineHeight);
 
         Text.Font = cache;
 
         if (SliderSettings.IsAlwaysOn)
         {
-            rect = new Rect(__state.MinimumEntryRect.Value.x + __state.MinimumEntryRect.Value.width + 5f, rect.y, usedWidth - 10f, rect.height);
+            rect = new Rect(__state.Item1.MinimumEntryRect.Value.x + __state.Item1.MinimumEntryRect.Value.width + 5f, rect.y, usedWidth - 10f, rect.height);
         }
 
         return true;
     }
 
-    private static void Postfix(Rect rect, ref IntRange range, int min, int max, [NotNull] ref NumberEntryController __state, bool ___continue)
+    private static void Postfix(Rect rect, ref IntRange range, int min, int max, [NotNull] ref (NumberEntryController, bool) __state)
     {
-        if (!___continue)
-        {
+        if (!__state.Item2)
             return;
-        }
 
         GameFont cache = Text.Font;
         Text.Font = GameFont.Tiny;
 
-        __state.BeginHysteresis(rect);
+        __state.Item1.BeginHysteresis(rect);
 
-        bool active = __state.IsCurrentlyActive();
+        bool active = __state.Item1.IsCurrentlyActive();
 
         if (active)
         {
-            __state.BeginLogging();
-            __state.Draw(ref range.min, ref range.max);
+            __state.Item1.BeginLogging();
+            __state.Item1.Draw(ref range.min, ref range.max);
         }
 
-        __state.EndHysteresis();
+        __state.Item1.EndHysteresis();
 
         if (!active)
         {
-            __state.EndLogging();
+            __state.Item1.EndLogging();
         }
 
         range.min = Mathf.Clamp(range.min, min, range.max);

--- a/Better Sliders/HarmonyPatches/ExpandedSliderInt.cs
+++ b/Better Sliders/HarmonyPatches/ExpandedSliderInt.cs
@@ -42,9 +42,18 @@ public static class ExpandedSliderInt
     }
 
     [SuppressMessage("ReSharper", "RedundantAssignment")]
-    private static void Prefix(ref Rect rect, IntRange range, [NotNull] ref NumberEntryController __state)
+    private static void Prefix(ref Rect rect, IntRange range, [NotNull] ref NumberEntryController __state, out bool __continue)
     {
-        __state = SliderController.ControllerForPosition(rect);
+        __continue = true;
+        var tempState = SliderController.ControllerForPosition(rect);
+
+        if (tempState == null)
+        {
+            __continue = false;
+            return;
+        }
+
+        __state = tempState;
         __state.SetStateIfNull(range.min, range.max);
 
         GameFont cache = Text.Font;
@@ -65,8 +74,13 @@ public static class ExpandedSliderInt
         }
     }
 
-    private static void Postfix(Rect rect, ref IntRange range, int min, int max, [NotNull] ref NumberEntryController __state)
+    private static void Postfix(Rect rect, ref IntRange range, int min, int max, [NotNull] ref NumberEntryController __state, bool __continue)
     {
+        if (!__continue)
+        {
+            return;
+        }
+
         GameFont cache = Text.Font;
         Text.Font = GameFont.Tiny;
 

--- a/Better Sliders/SliderController.cs
+++ b/Better Sliders/SliderController.cs
@@ -39,25 +39,31 @@ internal static class SliderController
     internal static NumberEntryController[] ControllersForWindow([NotNull] Window window) =>
         !WindowNumberControllers.TryGetValue(window.ID, out List<NumberEntryController> controllers) ? Array.Empty<NumberEntryController>() : controllers.ToArray();
 
-    [NotNull] internal static NumberEntryController[] ControllersForCurrentWindow() => ControllersForWindow(Find.WindowStack.currentlyDrawnWindow);
+  [NotNull]
+  internal static NumberEntryController[] ControllersForCurrentWindow() {
+    var window = Find.WindowStack.currentlyDrawnWindow ?? Find.WindowStack.focusedWindow;
+    if (window == null) return [];
+    return ControllersForWindow(window);
+  }
 
-    internal static NumberEntryController ControllerForPosition(Rect region)
+  internal static NumberEntryController ControllerForPosition(Rect region)
     {
         int groupId = GUIUtility.GetControlID(BeginGroupHashCode, FocusType.Passive);
 
         NumberEntryController controller;
 
-        if (Find.WindowStack.currentlyDrawnWindow == null)
+        var window = Find.WindowStack.currentlyDrawnWindow ?? Find.WindowStack.focusedWindow;
+        if (window == null)
         {
             return null;
         }
 
-        if (!WindowNumberControllers.TryGetValue(Find.WindowStack.currentlyDrawnWindow.ID, out List<NumberEntryController> controllers))
+        if (!WindowNumberControllers.TryGetValue(window.ID, out List<NumberEntryController> controllers))
         {
-            controller = new NumberEntryController { Parent = new System.WeakReference<Window>(Find.WindowStack.currentlyDrawnWindow), GroupId = groupId };
+            controller = new NumberEntryController { Parent = new System.WeakReference<Window>(window), GroupId = groupId };
 
             controllers = new List<NumberEntryController> { controller };
-            WindowNumberControllers[Find.WindowStack.currentlyDrawnWindow.ID] = controllers;
+            WindowNumberControllers[window.ID] = controllers;
 
             return controller;
         }
@@ -80,7 +86,7 @@ internal static class SliderController
             }
         }
 
-        controller = new NumberEntryController { Parent = new System.WeakReference<Window>(Find.WindowStack.currentlyDrawnWindow), GroupId = groupId };
+        controller = new NumberEntryController { Parent = new System.WeakReference<Window>(window), GroupId = groupId };
         controllers.Add(controller);
 
         return controller;
@@ -88,7 +94,9 @@ internal static class SliderController
 
     internal static void RemoveControllersForPosition(Rect region)
     {
-        if (!WindowNumberControllers.TryGetValue(Find.WindowStack.currentlyDrawnWindow.ID, out List<NumberEntryController> controllers))
+        var window = Find.WindowStack.currentlyDrawnWindow ?? Find.WindowStack.focusedWindow;
+        if (window is null) return;
+        if (!WindowNumberControllers.TryGetValue(window.ID, out List<NumberEntryController> controllers))
         {
             return;
         }

--- a/Better Sliders/SliderController.cs
+++ b/Better Sliders/SliderController.cs
@@ -41,12 +41,16 @@ internal static class SliderController
 
     [NotNull] internal static NumberEntryController[] ControllersForCurrentWindow() => ControllersForWindow(Find.WindowStack.currentlyDrawnWindow);
 
-    [NotNull]
     internal static NumberEntryController ControllerForPosition(Rect region)
     {
         int groupId = GUIUtility.GetControlID(BeginGroupHashCode, FocusType.Passive);
 
         NumberEntryController controller;
+
+        if (Find.WindowStack.currentlyDrawnWindow == null)
+        {
+            return null;
+        }
 
         if (!WindowNumberControllers.TryGetValue(Find.WindowStack.currentlyDrawnWindow.ID, out List<NumberEntryController> controllers))
         {


### PR DESCRIPTION
The gizmo to set the handler by a specific skill range, is not in an active window so it ends up throwing a `NullReferenceException` because `Find.WindowStack.currentlyDrawnWindow` is null at that point.   
There may be a better way to do this, but for now, the change just disables the new GUI parts on the gizmo.
